### PR TITLE
Change to new scoped Cloudant name: "@cloudant/cloudant"

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -14,7 +14,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-const cloudant = require('cloudant');
+const cloudant = require('@cloudant/cloudant');
 require('dotenv').load({ silent: true });
 const log = require('pino')();
 const cfenv = require('cfenv');

--- a/lib/statusdb.js
+++ b/lib/statusdb.js
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-const cloudant = require('cloudant');
+const cloudant = require('@cloudant/cloudant');
 require('dotenv').load({ silent: true });
 const log = require('pino')();
 const cfenv = require('cfenv');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "basic-auth": "^1.0.4",
     "body-parser": "^1.15.2",
     "cfenv": "1.0.x",
-    "cloudant": "^1.4.3",
+    "@cloudant/cloudant": "^1.4.3",
     "commander": "^2.9.0",
     "connect-multiparty": "2.0.x",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
Old package name `cloudant` is deprecated.