### PR TITLE
Remove deprecated metrics-tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/IBM/watson-multimedia-analyzer.svg?branch=master)](https://travis-ci.org/IBM/watson-multimedia-analyzer)
-![IBM Cloud Deployments](https://metrics-tracker.mybluemix.net/stats/f2eba8d669a9ca524414f940ecb3e8aa/badge.svg)
 
 # Using IBM Watson to enrich audio and visual files.
 
@@ -53,7 +52,7 @@ For convenience, we recommend that you use the ``Deploy to IBM Cloud`` button to
 * Once you have completed this journey, all of the Watson services can be automatically deleted along with deployed app.
 
 ## Deploy to IBM Cloud
-[![Deploy to IBM Cloud](https://metrics-tracker.mybluemix.net/stats/f2eba8d669a9ca524414f940ecb3e8aa/button.svg)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-multimedia-analyzer.git)
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-multimedia-analyzer.git)
 
 1. Press the above ``Deploy to IBM Cloud`` button and then click on ``Deploy``.
 
@@ -324,32 +323,3 @@ Solution - wait 24 hours to run again.
 # License
 
 [Apache 2.0](LICENSE)
-
-# Privacy Notice
-
-If using the ``Deploy to IBM Cloud`` button some metrics are tracked, the following
-information is sent to a [Deployment Tracker](https://github.com/IBM/metrics-collector-service) service
-on each deployment:
-
-* Node.js package version
-* Node.js repository URL
-* Application Name (`application_name`)
-* Application GUID (`application_id`)
-* Application instance index number (`instance_index`)
-* Space ID (`space_id`)
-* Application Version (`application_version`)
-* Application URIs (`application_uris`)
-* Labels of bound services
-* Number of instances for each bound service and associated plan information
-
-This data is collected from the `package.json` and `repository.yaml` file in the sample application and the ``VCAP_APPLICATION``
-and ``VCAP_SERVICES`` environment variables in IBM Cloud and other Cloud Foundry platforms. This
-data is used by IBM to track metrics around deployments of sample applications to IBM Cloud to
-measure the usefulness of our examples, so that we can continuously improve the content we offer
-to you. Only deployments of sample applications that include code to ping the Deployment Tracker
-service will be tracked.
-
-## Disabling Deployment Tracking
-
-To disable tracking, simply remove ``require('metrics-tracker-client').track();`` from the
-``app.js`` file in the top level directory.

--- a/app.js
+++ b/app.js
@@ -36,7 +36,6 @@ const fs = require('fs');
 
 pino.level = 'error';
 require('dotenv').load({ silent: true });
-require('metrics-tracker-client').track();
 
 const enrich = require('./lib/enricher').enrich;
 const enrichTone = require('./lib/enricher').enrich_tone;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "fs.extra": "^1.3.2",
     "html-entities": "^1.2.0",
     "method-override": "2.3.x",
-    "metrics-tracker-client": "*",
     "node-uuid": "^1.4.7",
     "pino": "^3.1.1",
     "request": "^2.79.0",


### PR DESCRIPTION
Remove:
Badge at top of README
Privacy Notice from Readme
Disabling Deployment Tracking from Readme
use of metric tracker in app:
i.e. require('metrics-tracker-client').track();
requirement.txt or package.json for metrics-tracker

Change D2B to:
https://bluemix.net/deploy/button.png